### PR TITLE
QoL patch - allow replacing HM moves

### DIFF
--- a/data/text/help_system.inc
+++ b/data/text/help_system.inc
@@ -2123,3 +2123,11 @@ Help_Text_DefineLGExclusives::
 	.string "MISDREAVUS, SNEASEL, REMORAID,\l"
 	.string "MANTINE, LATIAS, and their\l"
 	.string "evolutionary relatives.$"
+
+Help_Text_ForgetHM::
+	.string "FORGET HM MOVES$"
+
+Help_Text_DefineForgetHM::
+	.string "Set this option to ON to allow replacing\n"
+	.string "HM moves like regular moves when your\l"
+	.string "POKéMON is trying to learn a new move.$"

--- a/include/event_scripts.h
+++ b/include/event_scripts.h
@@ -1162,6 +1162,8 @@ extern const u8 Help_Text_DefineNuzlocke_Catching[];
 extern const u8 Help_Text_NuzlockeLosing[];
 extern const u8 Help_Text_DefineNuzlockeLosing[];
 extern const u8 Help_Text_DefineNoFreeHeals[];
+extern const u8 Help_Text_ForgetHM[];
+extern const u8 Help_Text_DefineForgetHM[];
 
 extern const u8 EventScript_FldEffStrength[];
 extern const u8 EventScript_FailSweetScent[];

--- a/include/global.h
+++ b/include/global.h
@@ -756,7 +756,6 @@ struct KeySystemFlags
     u16 noPMC:1;        //0 for normal, 1 for no Pokemon Center healing.
     u16 expMod:2;       //0 for 0x, 1 for 1/2x, 2 for 1x, 3 for 2x 
     u16 forgetHM:1;     //0 for normal, 1 to allow replacing hm moves
-    u16 padding:3;
     u16 changedCalcMode:1; //set if calc mode is changed to recalc party on save load
     u16 inKeySystemMenu:1; //Needed for Help Menu regardless of Button Mode
     u16 padding2;

--- a/include/global.h
+++ b/include/global.h
@@ -756,6 +756,7 @@ struct KeySystemFlags
     u16 noPMC:1;        //0 for normal, 1 for no Pokemon Center healing.
     u16 expMod:2;       //0 for 0x, 1 for 1/2x, 2 for 1x, 3 for 2x 
     u16 forgetHM:1;     //0 for normal, 1 to allow replacing hm moves
+    u16 padding:3;
     u16 changedCalcMode:1; //set if calc mode is changed to recalc party on save load
     u16 inKeySystemMenu:1; //Needed for Help Menu regardless of Button Mode
     u16 padding2;

--- a/include/global.h
+++ b/include/global.h
@@ -755,7 +755,8 @@ struct KeySystemFlags
     u16 evCalcMode:1;   //0 for normal, 1 for all zero
     u16 noPMC:1;        //0 for normal, 1 for no Pokemon Center healing.
     u16 expMod:2;       //0 for 0x, 1 for 1/2x, 2 for 1x, 3 for 2x 
-    u16 padding:4;
+    u16 forgetHM:1;     //0 for normal, 1 to allow replacing hm moves
+    u16 padding:3;
     u16 changedCalcMode:1; //set if calc mode is changed to recalc party on save load
     u16 inKeySystemMenu:1; //Needed for Help Menu regardless of Button Mode
     u16 padding2;

--- a/include/strings.h
+++ b/include/strings.h
@@ -1648,5 +1648,8 @@ extern const u8 gText_WhoAreThey[];
 extern const u8 gText_HowDoIBattleThem[];
 extern const u8 gText_AboutTitles[];
 extern const u8 gText_Nothing[];
+extern const u8 gText_ForgetHM[];
+extern const u8 gText_ForgetHM_On[];
+extern const u8 gText_ForgetHM_Off[];
 
 #endif //GUARD_STRINGS_H

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5092,7 +5092,7 @@ static void atk5A_yesnoboxlearnmove(void)
             {
                 u16 moveId = GetMonData(&gPlayerParty[gBattleStruct->expGetterMonId], MON_DATA_MOVE1 + movePosition);
                 
-                if (IsHMMove2(moveId))
+                if (IsHMMove2(moveId) && gSaveBlock1Ptr->keyFlags.forgetHM == 0)
                 {
                     PrepareStringBattle(STRINGID_HMMOVESCANTBEFORGOTTEN, gActiveBattler);
                     gBattleScripting.learnMoveState = 5;

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -920,7 +920,7 @@ static void Task_EvolutionScene(u8 taskId)
                 else
                 {
                     u16 move = GetMonData(mon, var + MON_DATA_MOVE1);
-                    if (IsHMMove2(move))
+                    if (IsHMMove2(move) && gSaveBlock1Ptr->keyFlags.forgetHM == 0)
                     {
                         BattleStringExpandPlaceholdersToDisplayedString(gBattleStringsTable[STRINGID_HMMOVESCANTBEFORGOTTEN - BATTLESTRINGS_ID_ADDER]);
                         BattlePutTextOnWindow(gDisplayedStringBattle, 0);
@@ -1269,7 +1269,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
                 else
                 {
                     u16 move = GetMonData(mon, var + MON_DATA_MOVE1);
-                    if (IsHMMove2(move))
+                    if (IsHMMove2(move) && gSaveBlock1Ptr->keyFlags.forgetHM == 0)
                     {
                         BattleStringExpandPlaceholdersToDisplayedString(gBattleStringsTable[STRINGID_HMMOVESCANTBEFORGOTTEN - BATTLESTRINGS_ID_ADDER]);
                         DrawTextOnTradeWindow(0, gDisplayedStringBattle, 1);

--- a/src/help_system.c
+++ b/src/help_system.c
@@ -463,6 +463,7 @@ enum
     HELP_TERM_BACK,
     HELP_TERM_ADVANCED,
     HELP_TERM_ADVANCED_KEYS_BACK,
+    HELP_TERM_FORGET_HM
 };
 
 static const u8 *const sHelpSystemTermTextPtrs[] = {
@@ -529,6 +530,7 @@ static const u8 *const sHelpSystemTermTextPtrs[] = {
     [HELP_TERM_BACK]           = Help_Text_Back,
     [HELP_TERM_ADVANCED]       = Help_Text_AdvancedKeys,
     [HELP_TERM_ADVANCED_KEYS_BACK] = Help_Text_Back,
+    [HELP_TERM_FORGET_HM]        = Help_Text_ForgetHM,
 };
 
 static const u8 *const sHelpSystemTermDefinitionsTextPtrs[] = {
@@ -595,6 +597,7 @@ static const u8 *const sHelpSystemTermDefinitionsTextPtrs[] = {
     [HELP_TERM_BACK]          = Help_Text_DefineBack,
     [HELP_TERM_ADVANCED]       = Help_Text_DefineAdvancedKeys,
     [HELP_TERM_ADVANCED_KEYS_BACK] = Help_Text_DefineAdvancedKeysBack,
+    [HELP_TERM_FORGET_HM] = Help_Text_DefineForgetHM,
 };
 
 // Submenu IDs for TOPIC_ABOUT_GAME
@@ -1718,6 +1721,7 @@ static const u8 sTerms_KeySystemSubMenu[] = {
     HELP_TERM_EV_CALC,
     HELP_TERM_NO_PMC,
     HELP_TERM_EXP_MOD,
+    HELP_TERM_FORGET_HM,
     HELP_TERM_ADVANCED_KEYS_BACK,
     HELP_END
 };

--- a/src/key_system_menu.c
+++ b/src/key_system_menu.c
@@ -32,6 +32,7 @@ enum
     MENUITEM_EV,
     MENUITEM_NO_PMC,
     MENUITEM_EXP_MOD,
+    MENUITEM_FORGET_HM,
     MENUITEM_BACK,
     MENUITEM_COUNT2
 };
@@ -144,7 +145,7 @@ static const struct BgTemplate sKeySystemMenuBgTemplates[] =
 
 static const u16 sKeySystemMenuPalette[] = INCBIN_U16("graphics/misc/unk_83cc2e4.gbapal");
 static const u16 sKeySystemMenuItemCounts[MENUITEM_COUNT] = {2, 3, 1, 0};
-static const u16 sKeySystemSubMenuItemCounts[MENUITEM_COUNT2] = {2, 3, 2, 2, 4, 0};
+static const u16 sKeySystemSubMenuItemCounts[MENUITEM_COUNT2] = {2, 3, 2, 2, 4, 2, 0};
 
 static const u8 *const sKeySystemMenuItemsNames[MENUITEM_COUNT] =
 {
@@ -160,6 +161,7 @@ static const u8 *const sKeySystemSubMenuItemsNames[MENUITEM_COUNT2] ={
     [MENUITEM_EV]         = gText_EVCalc,
     [MENUITEM_NO_PMC]     = gText_NoPMC,
     [MENUITEM_EXP_MOD]    = gText_ExpMod,
+    [MENUITEM_FORGET_HM]  = gText_ForgetHM,
     [MENUITEM_BACK]       = gText_Back,
 };
 
@@ -208,6 +210,12 @@ static const u8 *const sExpModOptions[] =
     gText_ExpModTwice
 };
 
+static const u8 *const sForgetHMOptions[] =
+{
+    gText_ForgetHM_Off,
+    gText_ForgetHM_On
+};
+
 static const u8 sKeySystemMenuPickSwitchCancelTextColor[] = {TEXT_DYNAMIC_COLOR_6, TEXT_COLOR_WHITE, TEXT_COLOR_DARK_GRAY};
 static const u8 sKeySystemMenuTextColor[] = {TEXT_COLOR_TRANSPARENT, TEXT_COLOR_LIGHT_RED, TEXT_COLOR_RED};
 
@@ -246,6 +254,7 @@ void CB2_KeySystemMenuFromContinueScreen(void)
     sKeySystemMenuPtr->subOption[MENUITEM_EV] = gSaveBlock1Ptr->keyFlags.evCalcMode;
     sKeySystemMenuPtr->subOption[MENUITEM_NO_PMC] = gSaveBlock1Ptr->keyFlags.noPMC;
     sKeySystemMenuPtr->subOption[MENUITEM_EXP_MOD] = gSaveBlock1Ptr->keyFlags.expMod;
+    sKeySystemMenuPtr->subOption[MENUITEM_FORGET_HM] = gSaveBlock1Ptr->keyFlags.forgetHM;
     if(gSaveBlock1Ptr->keyFlags.changedCalcMode != 1)
         gSaveBlock1Ptr->keyFlags.changedCalcMode = 0;
     gSaveBlock1Ptr->keyFlags.inKeySystemMenu = 1;
@@ -662,6 +671,9 @@ static void BufferKeySystemMenuString(u8 selection)
             case MENUITEM_EXP_MOD:
                 AddTextPrinterParameterized3(1, 2, x, y, dst, -1, sExpModOptions[sKeySystemMenuPtr->subOption[selection]]);
                 break;
+            case MENUITEM_FORGET_HM:
+                AddTextPrinterParameterized3(1, 2, x, y, dst, -1, sForgetHMOptions[sKeySystemMenuPtr->subOption[selection]]);
+                break;
             default:
                 break;
         }
@@ -686,6 +698,7 @@ static void CloseAndSaveKeySystemMenu(u8 taskId)
     gSaveBlock1Ptr->keyFlags.evCalcMode = sKeySystemMenuPtr->subOption[MENUITEM_EV];
     gSaveBlock1Ptr->keyFlags.noPMC = sKeySystemMenuPtr->subOption[MENUITEM_NO_PMC];
     gSaveBlock1Ptr->keyFlags.expMod = sKeySystemMenuPtr->subOption[MENUITEM_EXP_MOD];
+    gSaveBlock1Ptr->keyFlags.forgetHM = sKeySystemMenuPtr->subOption[MENUITEM_FORGET_HM];
     gSaveBlock1Ptr->keyFlags.inKeySystemMenu = 0;
     FREE_AND_SET_NULL(sKeySystemMenuPtr);
     DestroyTask(taskId);

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -155,6 +155,7 @@ void NewGameInitData(void)
     StringCopy(gSaveBlock1Ptr->rivalName, rivalName);
     ResetTrainerTowerResults();
     gSaveBlock1Ptr->keyFlags.expMod = 2; // normal exp
+    gSaveBlock1Ptr->keyFlags.forgetHM = 0; // do not allow replacing HM moves (standard behaviour)
 }
 
 static void ResetMiniGamesResults(void)

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -3983,6 +3983,9 @@ static u8 PokeSum_CanForgetSelectedMove(void)
     u16 move;
 
     move = GetMonMoveBySlotId(&sMonSummaryScreen->currentMon, sMoveSelectionCursorPos);
+    
+    if(gSaveBlock1Ptr->keyFlags.forgetHM == 1) // mod: always allow HM replace
+        return TRUE;
 
     if(IsMoveHm(move) && (gSaveBlock1Ptr->location.mapGroup == MAP_GROUP(TWO_ISLAND_HOUSE) && gSaveBlock1Ptr->location.mapNum == MAP_NUM(TWO_ISLAND_HOUSE)))
     {   //in Move Reminder's house

--- a/src/quest_log.c
+++ b/src/quest_log.c
@@ -823,6 +823,7 @@ static void QuestLog_StartFinalScene(void)
     u8 ChangedCalcBackup = gSaveBlock1Ptr->keyFlags.changedCalcMode;
     u8 noPMCBackup = gSaveBlock1Ptr->keyFlags.noPMC;
     u8 expModBackup = gSaveBlock1Ptr->keyFlags.expMod;
+    u8 forgetHMBackup = gSaveBlock1Ptr->keyFlags.forgetHM;
     ResetSpecialVars();
     Save_ResetSaveCounters();
     Save_LoadGameData(SAVE_NORMAL);
@@ -833,6 +834,7 @@ static void QuestLog_StartFinalScene(void)
     gSaveBlock1Ptr->keyFlags.evCalcMode = KeyEvCalcBackup;
     gSaveBlock1Ptr->keyFlags.noPMC = noPMCBackup;
     gSaveBlock1Ptr->keyFlags.expMod = expModBackup;
+    gSaveBlock1Ptr->keyFlags.forgetHM = forgetHMBackup;
     gSaveBlock1Ptr->keyFlags.changedCalcMode = 0;
     //recalculate party stats for IV and EV keys if they were changed
     if(ChangedCalcBackup == 1)

--- a/src/strings.c
+++ b/src/strings.c
@@ -1271,6 +1271,9 @@ const u8 gText_ExpModZero[] = _("0×");
 const u8 gText_ExpModHalf[] = _("1/2×");
 const u8 gText_ExpModNormal[] = _("1×");
 const u8 gText_ExpModTwice[] = _("2×");
+const u8 gText_ForgetHM[] = _("FORGET HM MOVES");
+const u8 gText_ForgetHM_On[] = _("ON");
+const u8 gText_ForgetHM_Off[] = _("OFF");
 
 const u8 gText_KeySystemSettings[] = _("KEY SYSTEM SETTINGS");
 const u8 gText_HelpPickSwitchCancel[] = _("{L_BUTTON}KEY INFO {DPAD_UPDOWN}PICK {DPAD_LEFTRIGHT}SWITCH {A_BUTTON}{B_BUTTON}SAVE");

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -723,6 +723,7 @@ static void SetTitleScreenScene_Cry(s16 * data)
             u8 ChangedCalcBackup = gSaveBlock1Ptr->keyFlags.changedCalcMode;
             u8 noPMCBackup = gSaveBlock1Ptr->keyFlags.noPMC;
             u8 expModBackup = gSaveBlock1Ptr->keyFlags.expMod;
+            u8 forgetHMBackup = gSaveBlock1Ptr->keyFlags.forgetHM;
             SeedRngAndSetTrainerId();
             SetSaveBlocksPointers();
             ResetMenuAndMonGlobals();
@@ -738,6 +739,7 @@ static void SetTitleScreenScene_Cry(s16 * data)
             gSaveBlock1Ptr->keyFlags.changedCalcMode = ChangedCalcBackup;
             gSaveBlock1Ptr->keyFlags.noPMC = noPMCBackup;
             gSaveBlock1Ptr->keyFlags.expMod = expModBackup;
+            gSaveBlock1Ptr->keyFlags.forgetHM = forgetHMBackup;
             SetPokemonCryStereo(gSaveBlock2Ptr->optionsSound);
             InitHeap(gHeap, HEAP_SIZE);
             SetMainCallback2(CB2_InitMainMenu);


### PR DESCRIPTION
QoL patch - new key option:
"**Forget HM Moves**": Allow replacing HM moves like regular moves (OFF by default)

Goes along well with the reusable TM improvement, to not have to use the move deleter npc if wanted to shuffle moves around in the overworld, also relieves the weight of HM decisions.

Hope I understood the padding thing on gSaveBlock1Ptr->keyFlags right (substracted 1 from padding field to make room for the new gSaveBlock1Ptr->keyFlags.forgetHM 0/1 flag)

TODO: 
* (nitpick warning) I remember at least one NPC having a dialog entry which says something like "hm's cannot be forgotten easily", replace that dialog by something else if the flag is on.
* on "trapped in cinnabar" softlock logic, skip the check for "all 4 moves are HM moves, hence surf/fly cannot be taught" if "forget hm moves" is ON