### PR TITLE
Fix build error due to incorrect filenames

### DIFF
--- a/src/tileset_anims.c
+++ b/src/tileset_anims.c
@@ -188,14 +188,14 @@ const u16 *const gTilesetAnims_BattleFrontierOutsideEast_Flower[] = {
     gTilesetAnims_BattleFrontierOutsideEast_Flower_Frame2
 };
 
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame0[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/0.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame1[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/1.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame2[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/2.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame3[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/3.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame4[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/4.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame5[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/5.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame6[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/6.4bpp");
-static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame7[] = INCBIN_U16("data/tilesets/secondary/SeviiIslands5/anim/mossdeep_tree_base/7.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame0[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/0.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame1[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/1.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame2[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/2.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame3[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/3.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame4[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/4.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame5[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/5.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame6[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/6.4bpp");
+static const u16 gTilesetAnims_Mossdeep_Tree_Base_Frame7[] = INCBIN_U16("data/tilesets/secondary/seviiislands5/anim/mossdeep_tree_base/7.4bpp");
 
 static const u16 *const gTilesetAnims_Mossdeep_Tree_Base[] = {
     gTilesetAnims_Mossdeep_Tree_Base_Frame0,


### PR DESCRIPTION
Most well designed operating systems and filesystems use filenames that are case sensitive. The correct path is all lowercase.

Yes, that was a roundabout "Linux is better" joke and yes I hate myself for it, heh.