### PR TITLE
Update FAQ.md to arrange bosses by ascending level caps

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -183,9 +183,9 @@ Misty: 22<br>
 Lt. Surge: 26<br>
 Rocket Hideout Giovanni: 31<br>
 Erika: 31<br>
-Koga: 46<br>
 Silph Co. Giovanni: 44<br>
 Sabrina: 46<br>
+Koga: 46<br>
 Blaine: 51<br>
 Leader Giovanni: 54<br>
 Lorelei: 58<br>


### PR DESCRIPTION
Put Silph Co. Giovanni before Sabrina and Koga since his cap is 2 levels lower than the other two